### PR TITLE
SRV-474/extract kafka lib

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,214 @@
-The MIT License (MIT)
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 
-Copyright © 2019 RentPath, LLC
+1. DEFINITIONS
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+"Contribution" means:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor tocontrol, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2019 RentPath
+Copyright © 2019 RentPath, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ FIXME
 
 ## License
 
-The MIT License
-
 Copyright © 2019 RentPath, LLC
+
+Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # rp-kafka-clj
-System components and protocols for Kafka stream processing applications
+
+A Clojure library providing various components (Stuart Sierra's Component library) and utilities for interacting with Kafka. This library assumes that all Kafka message keys and values are Avro-encoded using the Confluent Schema Registry.
+
+## Usage
+
+FIXME
+
+## License
+
+The MIT License
+
+Copyright © 2019 RentPath, LLC

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,18 @@
+(defproject rp-kafka-clj "0.0.0"
+  :description "Generic Clojure Kafka components and utils"
+  :url "https://gitthub.com/rentpath/rp-kafka-clj"
+  :license {:name "MIT"
+            :url "https://opensource.org/licenses/MIT"}
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [cheshire "5.8.0"]
+                 [org.apache.kafka/kafka-streams "2.1.0"]
+                 [io.confluent/kafka-streams-avro-serde "5.1.0"]
+                 [org.apache.avro/avro "1.8.2"]]
+  :repositories [["releases" {:url "https://nexus.tools.rentpath.com/repository/maven-releases/"
+                              :sign-releases false
+                              :username [:gpg :env/nexus_deploy_username]
+                              :password [:gpg :env/nexus_deploy_password]}]
+                 ["confluent" {:url "https://packages.confluent.io/maven/"}]]
+  :java-source-paths ["src/java"])

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject rp-kafka-clj "0.0.0"
+(defproject rp-kafka-clj "0.0.0-SNAPSHOT"
   :description "Generic Clojure Kafka components and utils"
   :url "https://gitthub.com/rentpath/rp-kafka-clj"
-  :license {:name "MIT"
-            :url "https://opensource.org/licenses/MIT"}
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [com.stuartsierra/component "0.3.2"]
@@ -10,9 +10,11 @@
                  [org.apache.kafka/kafka-streams "2.1.0"]
                  [io.confluent/kafka-streams-avro-serde "5.1.0"]
                  [org.apache.avro/avro "1.8.2"]]
-  :repositories [["releases" {:url "https://nexus.tools.rentpath.com/repository/maven-releases/"
-                              :sign-releases false
-                              :username [:gpg :env/nexus_deploy_username]
-                              :password [:gpg :env/nexus_deploy_password]}]
-                 ["confluent" {:url "https://packages.confluent.io/maven/"}]]
+  :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
+  :scm {:url "git@github.com:rentpath/rp-kafka-clj.git"}
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo/"
+                                     :username [:gpg :env/CLOJARS_USERNAME]
+                                     :password [:gpg :env/CLOJARS_PASSWORD]
+                                     :sign-releases false}]]
+  :global-vars {*warn-on-reflection* true}
   :java-source-paths ["src/java"])

--- a/script/release
+++ b/script/release
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Usage: ./scripts/release [release-level]
+#
+# This script exists to make the steps of `lein release` more
+# flexible and explicit.
+#
+# If no `release-level` is specified, expects to find a -SNAPSHOT
+# version in the project.clj file, removes the -SNAPSHOT suffix,
+# and releases that version.
+#
+# If a `release-level` argument is provided, the project will be
+# bumped to that level before releasing.
+
+set -eu
+
+E_BAD_ARGS=66
+
+DO_validateReleaseLevel() {
+    case $1 in
+        ":current")
+        ;;
+        ":minor")
+        ;;
+        ":major")
+        ;;
+        ":alpha")
+        ;;
+        ":beta")
+        ;;
+        ":rc")
+        ;;
+        *)
+            echo "The release level must be one of: :current, :minor, :major, :alpha, :beta, or :rc"
+            exit $E_BAD_ARGS
+            ;;
+esac
+}
+
+if [ $# -eq 1 ]; then
+    DO_validateReleaseLevel $1
+fi
+
+# For automated builds, this can be helpful.
+echo $(lein version)
+echo $(git --version)
+
+# Assumed `master` is main branch
+git checkout master
+
+lein test
+
+lein vcs assert-committed
+
+RELEASE_LEVEL="${1:-CURRENT_SNAPSHOT}"
+
+if [ "$RELEASE_LEVEL" = 'CURRENT_SNAPSHOT' ] || [ "$RELEASE_LEVEL" = ":current" ] ; then
+    echo "Using current version (sans -SNAPSHOT) as release version..."
+    lein change version leiningen.release/bump-version release
+else
+    echo "Bumping project version by $RELEASE_LEVEL level, then releasing..."
+    lein change version leiningen.release/bump-version $RELEASE_LEVEL
+    lein change version leiningen.release/bump-version release
+fi
+
+lein vcs commit
+
+export RELEASED_VERSION=v$(java -cp ~/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar clojure.main -e '(do (let [p (read-string (slurp "project.clj"))] (nth p 2)))' | tr -d '"')
+git tag -m "Release $RELEASED_VERSION" $RELEASED_VERSION
+
+lein do deploy releases, change version leiningen.release/bump-version
+lein do vcs commit, vcs push

--- a/src/java/GenericPrimitiveAvroSerde.java
+++ b/src/java/GenericPrimitiveAvroSerde.java
@@ -1,0 +1,64 @@
+// The problem: GenericAvroSerde doesn't handle primitive types (like KafkaAvroSerializer and KafkaAvroDeserializer do).
+// In other words, GenericAvroSerde cannot be used with a primitive key schema like "string" or "long"; it only works with GenericData records and null.
+// This solution comes from https://stackoverflow.com/questions/51955921/serde-class-for-avro-primitive-type
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+
+public class GenericPrimitiveAvroSerde<T> implements Serde<T> {
+
+    private final Serde<Object> inner;
+
+    /**
+     * Constructor used by Kafka Streams.
+     */
+    public GenericPrimitiveAvroSerde() {
+        inner = Serdes.serdeFrom(new KafkaAvroSerializer(), new KafkaAvroDeserializer());
+    }
+
+    public GenericPrimitiveAvroSerde(SchemaRegistryClient client) {
+        this(client, Collections.emptyMap());
+    }
+
+    public GenericPrimitiveAvroSerde(SchemaRegistryClient client, Map<String, ?> props) {
+        inner = Serdes.serdeFrom(new KafkaAvroSerializer(client), new KafkaAvroDeserializer(client, props));
+    }
+
+    @Override
+    public void configure(final Map<String, ?> serdeConfig, final boolean isSerdeForRecordKeys) {
+        inner.serializer().configure(serdeConfig, isSerdeForRecordKeys);
+        inner.deserializer().configure(serdeConfig, isSerdeForRecordKeys);
+    }
+
+    @Override
+    public void close() {
+        inner.serializer().close();
+        inner.deserializer().close();
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Serializer<T> serializer() {
+        Object obj = inner.serializer();
+        return (Serializer<T>) obj;
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Deserializer<T> deserializer() {
+        Object obj = inner.deserializer();
+        return (Deserializer<T>) obj;
+
+    }
+
+}

--- a/src/rp/kafka/avro.clj
+++ b/src/rp/kafka/avro.clj
@@ -1,0 +1,165 @@
+;; This is a modified verion of https://github.com/konukhov/kfk-avro-bridge/blob/master/src/thdr/kfk/avro_bridge/core.clj
+;; Removed the key munging (`camel-snake-kebab` stuff) which is too aggressive
+;; for our needs (for example, turning `addressline1` into
+;; `addressline_1` in `->java` and `addressline-1` in `->clj`).
+;; Then added limited munging in `->java` that just replaces `-` with `_` in keys.
+;; Removed Clojure 1.9 shims (so this requires 1.9)
+(ns rp.kafka.avro
+  (:require [clojure.string :as str])
+  (:import [java.nio ByteBuffer]
+           [org.apache.avro.generic
+            GenericData
+            GenericData$Record
+            GenericData$Array
+            GenericData$Fixed
+            GenericData$EnumSymbol]
+           [org.apache.avro.util Utf8]
+           [org.apache.avro Schema Schema$Type]))
+
+(defn avro-friendly-name
+  [k]
+  (str/replace (name k) "-" "_"))
+
+(defn- throw-invalid-type
+  [^Schema schema obj]
+  (throw (Exception. (format "Value `%s` cannot be cast to `%s` schema"
+                             (str obj)
+                             (.toString schema)))))
+
+(defn parse-schema
+  "A little helper for parsing schemas"
+  [json]
+  (Schema/parse json))
+
+(defn ->java
+  "Converts a Clojure data structure to an Avro-compatible
+   Java object. Avro `Schema` must be provided.
+   Hyphens in keys will be replaced with underscores, since hyphens are not
+   valid in Avro names."
+  [schema obj]
+  (condp = (and (instance? Schema schema) (.getType schema))
+    Schema$Type/NULL
+    (if (nil? obj)
+      nil
+      (throw-invalid-type schema obj))
+
+    Schema$Type/INT
+    (if (and (integer? obj) (<= Integer/MIN_VALUE obj Integer/MAX_VALUE))
+      (int obj)
+      (throw-invalid-type schema obj))
+
+    Schema$Type/LONG
+    (if (and (integer? obj) (<= Long/MIN_VALUE obj Long/MAX_VALUE))
+      (long obj)
+      (throw-invalid-type schema obj))
+
+    Schema$Type/FLOAT
+    (if (float? obj)
+      (float obj)
+      (throw-invalid-type schema obj))
+
+    Schema$Type/DOUBLE
+    (if (float? obj)
+      (double obj)
+      (throw-invalid-type schema obj))
+
+    Schema$Type/BOOLEAN
+    (if (boolean? obj)
+      obj
+      (throw-invalid-type schema obj))
+
+    Schema$Type/STRING
+    (if (string? obj)
+      obj
+      (throw-invalid-type schema obj))
+
+    Schema$Type/BYTES
+    (if (bytes? obj)
+      (doto (ByteBuffer/allocate (count obj))
+        (.put obj)
+        (.position 0))
+      (throw-invalid-type schema obj))
+
+    Schema$Type/ARRAY ;; TODO Exception for complex type
+    (let [f (partial ->java (.getElementType schema))]
+      (GenericData$Array. schema (map f obj)))
+
+    Schema$Type/FIXED
+    (if (and (bytes? obj) (= (count obj) (.getFixedSize schema)))
+      (GenericData$Fixed. schema obj)
+      (throw-invalid-type schema obj))
+
+    Schema$Type/ENUM
+    (let [enum (name obj)
+          enums (into #{} (.getEnumSymbols schema))]
+      (if (contains? enums enum)
+        (GenericData$EnumSymbol. schema enum)
+        (throw-invalid-type schema enum)))
+
+    Schema$Type/MAP ;; TODO Exception for complex type
+    (zipmap (map avro-friendly-name (keys obj))
+            (map (partial ->java (.getValueType schema))
+                 (vals obj)))
+
+    Schema$Type/UNION
+    (let [[val matched]
+          (reduce (fn [_ schema]
+                    (try
+                      (reduced [(->java schema obj) true])
+                      (catch Exception _
+                        [nil false])))
+                  [nil false]
+                  (.getTypes schema))]
+      (if matched
+        val
+        (throw-invalid-type schema obj)))
+
+    Schema$Type/RECORD
+    (reduce-kv
+     (fn [record k v]
+       (let [k (avro-friendly-name k)
+             s (some-> (.getField schema k)
+                       (as-> f (.schema f)))]
+         (doto record
+           (.put k (->java (or s k) v)))))
+     (GenericData$Record. schema)
+     obj)
+
+    (throw (Exception. (format "Field `%s` is not in schema" schema)))))
+
+(defn ->clj
+  "Parses deserialized Avro object into
+   a Clojure data structure. Keys in records
+   and maps + enums will get keywordized."
+  [msg]
+  (condp instance? msg
+    Utf8
+    (str msg)
+
+    java.nio.ByteBuffer
+    (.array msg)
+
+    GenericData$Array
+    (into [] (map ->clj msg))
+
+    GenericData$Fixed
+    (.bytes msg)
+
+    GenericData$EnumSymbol
+    (keyword (str msg))
+
+    java.util.Map
+    (zipmap (map (comp keyword str) (keys msg))
+            (map ->clj (vals msg)))
+
+    GenericData$Record
+    (loop [fields (seq (.. msg getSchema getFields)) record {}]
+      (if-let [f (first fields)]
+        (let [n (.name f)
+              v (->clj (.get msg n))
+              k (keyword n)]
+          (recur (rest fields)
+                 (assoc record k v)))
+        record))
+
+    msg))

--- a/src/rp/kafka/common.clj
+++ b/src/rp/kafka/common.clj
@@ -1,0 +1,13 @@
+(ns rp.kafka.common
+  (:require [clojure.tools.logging :as log]))
+
+(defn report-throwable [component throwable & [msg extra]]
+  "General handler for throwables that don't bubble up to the main thread.
+  Components may opt to provide a :throwable-callback function to report
+  these throwables (e.g. to Sentry)."
+  ;; Optional args:
+  ;; msg (string)
+  ;; extra (map of misc extra info)
+  (log/error throwable msg extra)
+  (when-let [callback (:throwable-callback component)]
+    (callback component throwable msg extra)))

--- a/src/rp/kafka/kafka_admin.clj
+++ b/src/rp/kafka/kafka_admin.clj
@@ -1,0 +1,60 @@
+(ns rp.kafka.kafka-admin
+  (:import [org.apache.kafka.clients.admin AdminClient AdminClientConfig NewTopic]))
+
+(defn ->AdminClient
+  "Convenient factory for constructing an AdminClient.
+  The caller is responsible for calling `.close` on the client when its no longer needed."
+  ^AdminClient [bootstrap-servers]
+  (AdminClient/create {AdminClientConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers}))
+
+(defn map->NewTopic
+  "Creates a NewTopic from a config map. Minimum config is just :name."
+  [{:keys [name partition-count replication-factor] :as m}]
+  (NewTopic. ^String name
+             (or partition-count 1)
+             (or replication-factor 1)))
+
+(defn list-topics
+  [client]
+  (-> client .listTopics .names deref sort))
+
+;; Does not block until the created topics are ready.
+;; It may take some time for replicas and leaders to be chosen for newly created topics.
+(defn create-topics!
+  [client topic-configs]
+  (->> (.createTopics client (map map->NewTopic topic-configs))
+       .all deref))
+
+;; Does not block until the topics are deleted, just until the deletion
+;; requests are acknowledged.
+;; Throws an exception if any of the topics don't exist.
+(defn delete-topics!
+  [client topic-names]
+  (-> (.deleteTopics client topic-names)
+      .all deref))
+
+(defn re-delete-topics!
+  "Delete topics matching a regex."
+  [client re]
+  (let [topics-to-delete (filter #(re-find re %)
+                                 (list-topics client))]
+    (delete-topics! client topics-to-delete)))
+
+;; FIXME: For general re-use, it would be nice for this to return a data map for each topic.
+;; jackdaw does that by providing datafy implementations for all of the java objects.
+;; However right now all I really care about is partition count.
+(defn- describe-topics
+  [client topic-names]
+  (-> (.describeTopics client topic-names)
+      .all
+      deref))
+
+(defn- describe-topic
+  [client topic-name]
+  (get (describe-topics client [topic-name]) topic-name))
+
+(defn partition-count
+  [client topic-name]
+  (-> (describe-topic client topic-name)
+      .partitions
+      count))

--- a/src/rp/kafka/kafka_publisher.clj
+++ b/src/rp/kafka/kafka_publisher.clj
@@ -1,0 +1,78 @@
+(ns rp.kafka.kafka-publisher
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [com.stuartsierra.component :as component]
+            [rp.kafka.publisher :as publisher]
+            [rp.kafka.avro :as avro]
+            [rp.kafka.common :as common])
+  (:import [org.apache.kafka.clients.producer Callback KafkaProducer ProducerConfig ProducerRecord]
+           [io.confluent.kafka.serializers AbstractKafkaAvroSerDeConfig KafkaAvroSerializer]
+           [java.util Properties]))
+
+(defn report-success [component k v metadata]
+  ;; Call success-callback (when specified)
+  (when-let [callback (:success-callback component)]
+    (callback component k v metadata)))
+
+;; A helper for multiple artity protocol method.
+(defn- publish*
+  [{:keys [topic key-schema value-schema producer] :as component} k v {:keys [partition] :as opts}]
+  (.send producer
+         (let [k-payload (and k (avro/->java key-schema k))
+               v-payload (and v (avro/->java value-schema v))]
+           (if partition
+             (ProducerRecord. topic (int partition) k-payload v-payload)
+             (ProducerRecord. topic k-payload v-payload)))
+         (reify Callback
+           (onCompletion [_ metadata e]
+             (if e
+               (common/report-throwable component e "Failed to send record to Kafka" {:k k :v v :opts opts})
+               (report-success component k v metadata))))))
+
+(defrecord KafkaPublisher [bootstrap-servers topic schema-registry-url key-schema value-schema auto-register-schemas?]
+  component/Lifecycle
+  (start [this]
+    (let [config {ProducerConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers
+                  ProducerConfig/KEY_SERIALIZER_CLASS_CONFIG KafkaAvroSerializer
+                  ProducerConfig/VALUE_SERIALIZER_CLASS_CONFIG KafkaAvroSerializer
+                  AbstractKafkaAvroSerDeConfig/SCHEMA_REGISTRY_URL_CONFIG schema-registry-url
+                  AbstractKafkaAvroSerDeConfig/AUTO_REGISTER_SCHEMAS auto-register-schemas?}
+          producer (KafkaProducer. config)]
+      (assoc this :producer producer)))
+  (stop [{:keys [producer] :as this}]
+    (when producer
+      (.flush producer)
+      (.close producer))
+    (dissoc this :producer))
+
+  publisher/Publisher
+  (publish [this k v opts]
+    (publish* this k v opts))
+  (publish [this k v]
+    (publish* this k v nil)))
+
+(comment
+  (require '[cheshire.core :as json])
+  (def value-schema (-> {:type "record"
+                         :name "Test"
+                         :fields [{:name "x" :type "string"}]}
+                        json/encode
+                        avro/parse-schema))
+  (def key-schema (avro/parse-schema "string"))
+  (def pub (map->KafkaPublisher
+            {:bootstrap-servers "kafka:9092"
+             :topic "foo"
+             :key-schema key-schema
+             :value-schema value-schema
+             :schema-registry-url "http://schema_registry:8081"
+             :auto-register-schemas? true}))
+  (def pub (component/start pub))
+  (publisher/publish pub
+                     "test"
+                     {:x "Hi"})
+  (publisher/publish pub
+                     "test"
+                     ;; V = nil indicates deletion
+                     nil)
+  (def pub (component/stop pub))
+  )

--- a/src/rp/kafka/kafka_state_store.clj
+++ b/src/rp/kafka/kafka_state_store.clj
@@ -1,0 +1,54 @@
+(ns rp.kafka.kafka-state-store
+  "Adds a protocol-based wrapper for interacting with KV state stores.
+  Opens the door for mocking."
+  (:require [cheshire.core :as json])
+  (:import [org.apache.kafka.streams.state KeyValueStore]))
+
+(defprotocol KVStore
+  (get-key [this k] "Gets the value for key")
+  (set-key [this k v] "Sets the value for key; deletes key when value is nil."))
+
+(extend-type KeyValueStore
+  KVStore
+  (get-key [this k]
+    (.get this (name k)))
+  (set-key [this k v]
+    (.put this (name k) v)))
+
+;; A couple of convenience functions for dealing with values as json strings:
+
+(defn get-json
+  [kvstore k]
+  (let [v (get-key kvstore k)]
+    (and v (json/decode v true))))
+
+(defn set-json
+  [kvstore k v]
+  (set-key kvstore k (and v (json/encode v))))
+
+(defrecord MockKVStore [store]
+  KVStore
+  (get-key [this k]
+    (get @store (keyword k)))
+  (set-key [this k v]
+    (if v
+      (swap! store assoc (keyword k) v)
+      (swap! store dissoc (keyword k)))
+    nil))
+
+(defn- print-kv-iter
+  "Helper for print-state-store"
+  [iter]
+  (when (.hasNext iter)
+    (let [kv (.next iter)]
+      (prn kv))
+    (print-kv-iter iter)))
+
+(defn print-state-store
+  "Print all the keys/values in a KeyValueStore. Handy for dev debugging."
+  [state-store]
+  (println "=== Start printing state store ===")
+  (let [iter (.all state-store)]
+    (print-kv-iter iter)
+    (.close iter))
+    (println "=== Done printing state store ==="))

--- a/src/rp/kafka/kafka_stream_dsl_processor.clj
+++ b/src/rp/kafka/kafka_stream_dsl_processor.clj
@@ -1,0 +1,176 @@
+(ns rp.kafka.kafka-stream-dsl-processor
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.logging :as log]
+            [rp.kafka.avro :as avro]
+            [rp.kafka.common :as common])
+  (:import [org.apache.kafka.common.serialization Serdes]
+           [org.apache.kafka.streams KafkaStreams StreamsBuilder StreamsConfig Topology KeyValue]
+           [org.apache.kafka.streams.errors DeserializationExceptionHandler LogAndContinueExceptionHandler]
+           [org.apache.kafka.streams.processor Processor ProcessorContext ProcessorSupplier]
+           [org.apache.kafka.streams.kstream KStream Printed Initializer Aggregator Merger TimeWindows SessionWindows KeyValueMapper Suppressed Suppressed$BufferConfig Materialized Predicate]
+           GenericPrimitiveAvroSerde
+           [io.confluent.kafka.serializers AbstractKafkaAvroSerDeConfig KafkaAvroDeserializer]
+           [java.util Properties]))
+
+;;
+;; Handy stuff "borrowed" from https://github.com/FundingCircle/jackdaw/blob/master/src/jackdaw/streams/lambdas.clj
+;;
+
+(defn key-value
+  "A key-value pair defined for a single Kafka Streams record."
+  [[key value]]
+  (KeyValue. key value))
+
+(deftype FnInitializer [initializer-fn]
+  Initializer
+  (apply [this]
+    (initializer-fn)))
+
+(defn initializer
+  "Packages up a Clojure fn in a kstream Initializer."
+  ^Initializer [initializer-fn]
+  (FnInitializer. initializer-fn))
+
+(deftype FnAggregator [aggregator-fn]
+  Aggregator
+  (apply [this agg-key value aggregate]
+    (aggregator-fn aggregate [agg-key value])))
+
+(defn aggregator
+  "Packages up a Clojure fn in a kstream Aggregator."
+  ^Aggregator [aggregator-fn]
+  (FnAggregator. aggregator-fn))
+
+(deftype FnKeyValueMapper [key-value-mapper-fn]
+  KeyValueMapper
+  (apply [this key value]
+    (key-value (key-value-mapper-fn [key value]))))
+
+(defn key-value-mapper
+  "Packages up a Clojure fn in a kstream key value mapper."
+  [key-value-mapper-fn]
+  (FnKeyValueMapper. key-value-mapper-fn))
+
+(deftype FnPredicate [predicate-fn]
+  Predicate
+  (test [this key value]
+    (boolean (predicate-fn [key value]))))
+
+(defn predicate
+  "Packages up a Clojure fn in a kstream predicate."
+  [predicate-fn]
+  (FnPredicate. predicate-fn))
+
+;;
+;; End of jackdaw stuff
+;;
+
+;; Note: Jackdaw doesn't include a wrapper for Merger (for aggregating session windows), so let's add it.
+(deftype FnMerger [merger-fn]
+  Merger
+  (apply [this agg-key aggregate1 aggregate2]
+    (merger-fn agg-key aggregate1 aggregate2)))
+
+(defn merger
+  "Packages up a Clojure fn in a kstream Merger"
+  ^Merger [merger-fn]
+  (FnMerger. merger-fn))
+
+;;
+;; Wrappers that deal with Avro schema serde concerns for us.
+;;
+
+(defn avro-initializer
+  [agg-schema initializer-fn]
+  (initializer
+   (fn []
+     (let [init-agg (initializer-fn)]
+       (log/info "in initializer" {:init-agg init-agg}) ; FIXME: del eventually
+       (avro/->java agg-schema init-agg)))))
+
+(defn avro-aggregator
+  [agg-schema aggregator-fn]
+  (aggregator
+   (fn [agg [k v]]
+     (let [k (and k (avro/->clj k))
+           v (and v (avro/->clj v))
+           agg (and agg (avro/->clj agg))
+           new-agg (aggregator-fn agg [k v])]
+       (log/info "in aggregator" {:k k :v v :agg agg :new-agg new-agg}) ; FIXME: del eventually
+       (avro/->java agg-schema new-agg)))))
+
+(defn avro-merger
+  [agg-schema merger-fn]
+  (merger
+   (fn [k agg1 agg2]
+     (let [k (and k (avro/->clj k))
+           agg1 (and agg1 (avro/->clj agg1))
+           agg2 (and agg2 (avro/->clj agg2))
+           new-agg (merger-fn k agg1 agg2)]
+       (log/info "in merger" {:k k :agg1 agg1 :agg2 agg2 :new-agg new-agg}) ; FIXME: del eventually
+       (avro/->java agg-schema new-agg)))))
+
+(defn time-windows
+  ;; Hopping (overlapping) windows, where advance-by-duration is less than window-duration.
+  ([window-duration advance-by-duration]
+   (let [windows (TimeWindows/of window-duration)]
+     (if advance-by-duration
+       (.advanceBy windows advance-by-duration)
+       windows)))
+  ;; Tumbling (non-overlapping, gap-less) windows, where advance-by-duration is the same as window-duration.
+  ([window-duration]
+   (time-windows window-duration nil)))
+
+(defn session-windows
+  [inactivity-duration]
+  (SessionWindows/with inactivity-duration))
+
+;; Returns a value for passing to KTable#suppress method
+;; See https://kafka.apache.org/21/javadoc/org/apache/kafka/streams/kstream/Suppressed.html#untilWindowCloses-org.apache.kafka.streams.kstream.Suppressed.StrictBufferConfig-
+;; https://cwiki.apache.org/confluence/display/KAFKA/KIP-328%3A+Ability+to+suppress+updates+for+KTables
+;; FIXME: When "spill to disk" buffer config is available, use that instead of "unbounded".
+;; https://issues.apache.org/jira/browse/KAFKA-7224
+(defn suppressed-until-window-closes
+  []
+  (Suppressed/untilWindowCloses
+   (Suppressed$BufferConfig/unbounded)))
+
+;; Returns a value to pass as explicit Materialized arg to stateful transformations (like aggregate). Seems to be necessary (at least with kafka-streams 2.1.0) when using `suppress`.
+;; See https://stackoverflow.com/a/54115693/11023580
+(defn materialized-with-avro
+  [schema-registry-url]
+  (let [config {AbstractKafkaAvroSerDeConfig/SCHEMA_REGISTRY_URL_CONFIG schema-registry-url}]
+    (Materialized/with (doto (GenericPrimitiveAvroSerde.)
+                         (.configure config true))
+                       (doto (GenericPrimitiveAvroSerde.)
+                         (.configure config false)))))
+
+(defrecord KafkaStreamDslProcessor [bootstrap-servers schema-registry-url app-id input-topics process-input-stream auto-register-schemas?]
+  component/Lifecycle
+  (start [this]
+    ;; Ugh; KafkaStreams constructor requires Properties for config
+    ;; (which limits us to only string values).
+    (let [config (doto (Properties.)
+                   (.setProperty StreamsConfig/APPLICATION_ID_CONFIG app-id)
+                   (.setProperty StreamsConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers)
+                   (.setProperty StreamsConfig/DEFAULT_KEY_SERDE_CLASS_CONFIG (.getName GenericPrimitiveAvroSerde))
+                   (.setProperty StreamsConfig/DEFAULT_VALUE_SERDE_CLASS_CONFIG (.getName GenericPrimitiveAvroSerde))
+                   ;; Ideally we'd log deserialization errors to Sentry as well, but the use of string properties for config makes that convoluted.
+                   ;; We could create a custom handler class, but we can't pass the error-handler object to it; the best we could do is pass the DSN string as custom config and use that to construct another error handler instance. IMO not worth the hassle.
+                   (.setProperty StreamsConfig/DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG (.getName LogAndContinueExceptionHandler))
+                   (.setProperty AbstractKafkaAvroSerDeConfig/SCHEMA_REGISTRY_URL_CONFIG schema-registry-url)
+                   (.setProperty AbstractKafkaAvroSerDeConfig/AUTO_REGISTER_SCHEMAS (str (boolean auto-register-schemas?))))
+          builder (StreamsBuilder.)
+          input-stream (.stream builder input-topics)
+          ;; The following mutates the builder as a side-effect.
+          _ (process-input-stream this input-stream)
+          topology (.build builder)
+          streams (KafkaStreams. topology config)]
+      (.start streams)
+      (assoc this :streams streams)))
+  (stop [this]
+    (try
+      (.close (:streams this))
+      (catch Throwable t
+        (common/report-throwable this t "Caught exception closing streams" {:app-id app-id})))
+    this))

--- a/src/rp/kafka/kafka_stream_processor.clj
+++ b/src/rp/kafka/kafka_stream_processor.clj
@@ -1,0 +1,107 @@
+;; FIXME: Consider refactoring/deprecating; one could use Kstream's `process` method with a DSL stream processor instead.
+;; See https://kafka.apache.org/21/javadoc/org/apache/kafka/streams/kstream/KStream.html#process-org.apache.kafka.streams.processor.ProcessorSupplier-java.lang.String...-
+(ns rp.kafka.kafka-stream-processor
+  "A Stream Processor component (using the lower-level Processor API, not the DSL API).
+  Note that (at least for now) this wraps a simple topology with a single source (which may be multiple topics), a single processor (with optional state store) and a single sink topic."
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.logging :as log]
+            [rp.kafka.avro :as avro]
+            [rp.kafka.common :as common])
+  (:import [org.apache.kafka.common.serialization Serdes]
+           [org.apache.kafka.streams KafkaStreams StreamsConfig Topology]
+           [org.apache.kafka.streams.errors DeserializationExceptionHandler LogAndContinueExceptionHandler]
+           [org.apache.kafka.streams.processor Processor ProcessorContext ProcessorSupplier]
+           [org.apache.kafka.streams.state Stores]
+           GenericPrimitiveAvroSerde
+           [io.confluent.kafka.serializers AbstractKafkaAvroSerDeConfig KafkaAvroDeserializer]
+           [java.util Properties]))
+
+(defn str-array
+  "Helper for passing a vararg of Strings to a Java method."
+  [& strings]
+  (into-array String strings))
+
+(defn state-store-builder
+  "Returns a builder for a persistent store with the specified name. The store keys and values are both strings."
+  [store-name]
+  (Stores/keyValueStoreBuilder
+   (Stores/persistentKeyValueStore store-name)
+   (Serdes/String)
+   (Serdes/String)))
+
+(defn process-record
+  [component context state-store {:keys [k v meta] :as rec}]
+  (let [{:keys [record-callback output-key-schema output-value-schema]} component]
+    (log/info {:rec rec})               ; FIXME: del eventually
+    (try
+      (let [output-recs (record-callback {:k (and k (avro/->clj k))
+                                          :v (and v (avro/->clj v))
+                                          :meta meta
+                                          :component component
+                                          :state-store state-store})]
+        (doseq [{:keys [k v] :as rec-out} output-recs]
+          (log/info {:rec-out rec-out}) ; FIXME: del eventually
+          (.forward context
+                    (and k (avro/->java output-key-schema k))
+                    (and v (avro/->java output-value-schema v)))))
+      (catch Throwable t
+        (common/report-throwable component t "Caught exception handling record" {:rec rec})))))
+
+(deftype CustomProcessor [component
+                          ^{:volatile-mutable true} context
+                          ^{:volatile-mutable true} state-store]
+  Processor
+
+  (^void init [this ^ProcessorContext c]
+   (set! context c)
+   (when-let [store-name (:store-name component)]
+     (set! state-store (.getStateStore context store-name))))
+
+  (process [this k v]
+    (let [meta {:topic (.topic context)
+                :partition (.partition context)
+                :offset (.offset context)
+                :timestamp (.timestamp context)}
+          rec {:k k :v v :meta meta}]
+      (process-record component context state-store rec)))
+
+  (close [this]
+    ;; No-op (just defined to satisfy interface)
+    ;; Used to close state store here, but learned the hard way that we shouldn't bother to close the store.
+    ;; https://issues.apache.org/jira/browse/KAFKA-4919
+    ))
+
+(defrecord KafkaStreamProcessor [bootstrap-servers schema-registry-url app-id input-topics output-topic output-key-schema output-value-schema record-callback store-name auto-register-schemas?]
+  component/Lifecycle
+  (start [this]
+    ;; Ugh; KafkaStreams constructor requires Properties for config
+    ;; (which limits us to only string values).
+    (let [config (doto (Properties.)
+                   (.setProperty StreamsConfig/APPLICATION_ID_CONFIG app-id)
+                   (.setProperty StreamsConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers)
+                   (.setProperty StreamsConfig/DEFAULT_KEY_SERDE_CLASS_CONFIG (.getName GenericPrimitiveAvroSerde))
+                   (.setProperty StreamsConfig/DEFAULT_VALUE_SERDE_CLASS_CONFIG (.getName GenericPrimitiveAvroSerde))
+                   ;; Ideally we'd log deserialization errors to Sentry as well, but the use of string properties for config makes that convoluted.
+                   ;; We could create a custom handler class, but we can't pass the error-handler object to it; the best we could do is pass the DSN string as custom config and use that to construct another error handler instance. IMO not worth the hassle.
+                   (.setProperty StreamsConfig/DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG (.getName LogAndContinueExceptionHandler))
+                   (.setProperty AbstractKafkaAvroSerDeConfig/SCHEMA_REGISTRY_URL_CONFIG schema-registry-url)
+                   (.setProperty AbstractKafkaAvroSerDeConfig/AUTO_REGISTER_SCHEMAS (str (boolean auto-register-schemas?))))
+          topology (-> (Topology.)
+                       (.addSource "Source" (apply str-array input-topics))
+                       (.addProcessor "Process"
+                                      (reify ProcessorSupplier
+                                        (get [_] (->CustomProcessor this nil nil)))
+                                      (str-array "Source"))
+                       (.addSink "Sink" output-topic (str-array "Process")))
+          topology (cond-> topology
+                     store-name (.addStateStore (state-store-builder store-name)
+                                                (str-array "Process")))
+          streams (KafkaStreams. topology config)]
+      (.start streams)
+      (assoc this :streams streams)))
+  (stop [this]
+    (try
+      (.close (:streams this))
+      (catch Throwable t
+        (common/report-throwable this t "Caught exception closing streams" {:app-id app-id})))
+    this))

--- a/src/rp/kafka/kafka_subscriber.clj
+++ b/src/rp/kafka/kafka_subscriber.clj
@@ -1,0 +1,108 @@
+(ns rp.kafka.kafka-subscriber
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.logging :as log]
+            [rp.kafka.avro :as avro]
+            [rp.kafka.common :as common])
+  (:import [org.apache.kafka.clients.consumer KafkaConsumer ConsumerConfig ConsumerRecords]
+           [org.apache.kafka.common TopicPartition]
+           [org.apache.kafka.common.errors SerializationException]
+           [io.confluent.kafka.serializers AbstractKafkaAvroSerDeConfig KafkaAvroDeserializer]
+           [java.util Properties]))
+
+(defn seek-past-error
+  [consumer e]
+  ;; Annoyingly the exception doesn't provide the details as data so we have to parse the error message.
+  ;; Example message: "Error deserializing key/value for partition foo-0 at offset 2. If needed, please seek past the record to continue consumption."
+  (let [msg (.getMessage e)
+        match (re-find #"partition (.+)-(\d+) at offset (\d+)" msg)]
+    (if match
+      (let [[_ topic partition offset] match
+            partition (Long/parseLong partition)
+            offset (Long/parseLong offset)]
+        (log/info "Trying to seek past bad record" {:topic topic :partition partition :offset offset})
+        (.seek consumer (TopicPartition. topic partition) (inc offset)))
+      (throw (ex-info "Failed to parse serialization error; can't seek past bad message." {:msg msg})))))
+
+(defn fetch-records
+  [{:keys [consumer poll-timeout-ms] :as component}]
+  (try (vec (.poll consumer poll-timeout-ms))
+       (catch SerializationException e
+         (common/report-throwable component e "Caught SerializationException calling .poll")
+         (seek-past-error consumer e)
+         [])))
+
+(defn commit-offsets
+  [{:keys [consumer] :as component}]
+  (try
+    (.commitSync consumer)
+    (catch Throwable t
+      (common/report-throwable component t "Caught exception committing offsets"))))
+
+(defn poll
+  [{:keys [consumer record-callback] :as component}]
+  (let [recs (fetch-records component)]
+    (doseq [rec recs]
+      (log/info {:rec rec}) ; FIXME: del eventually
+      (try
+        (let [k (.key rec)
+              v (avro/->clj (.value rec))
+              meta {:topic (.topic rec)
+                    :partition (.partition rec)
+                    :offset (.offset rec)
+                    :timestamp (.timestamp rec)}]
+          ;; FIXME: switch to this style after initial alert-service migration
+          #_(record-callback {:component component
+                            :k k
+                            :v v
+                            :meta meta})
+          (record-callback component k v meta))
+        (catch Throwable t
+          (common/report-throwable component t "Caught exception handling record" {:rec rec}))))
+    (when (seq recs)
+      (commit-offsets component))))
+
+(defrecord KafkaSubscriber [bootstrap-servers group-id topics schema-registry-url poll-timeout-ms record-callback]
+  component/Lifecycle
+  (start [this]
+    (let [config {ConsumerConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers
+                  ConsumerConfig/GROUP_ID_CONFIG group-id
+                  ConsumerConfig/KEY_DESERIALIZER_CLASS_CONFIG KafkaAvroDeserializer
+                  ConsumerConfig/VALUE_DESERIALIZER_CLASS_CONFIG KafkaAvroDeserializer
+                  AbstractKafkaAvroSerDeConfig/SCHEMA_REGISTRY_URL_CONFIG schema-registry-url
+                  ConsumerConfig/AUTO_OFFSET_RESET_CONFIG "latest"
+                  ConsumerConfig/ENABLE_AUTO_COMMIT_CONFIG false}
+          consumer (KafkaConsumer. config)
+          component (assoc this
+                           :consumer consumer
+                           :running? (atom true))]
+      (assoc component :poll-loop-future
+             (future (try
+                       (.subscribe consumer topics)
+                       (while @(:running? component) (poll component))
+                       (catch Throwable t
+                         (common/report-throwable component t "Caught exception running poll loop")))
+                     (log/info "Poll loop stopped running for" topics)
+                     (try
+                       (.close consumer)
+                       (catch Throwable t
+                         (common/report-throwable component t "Caught exception closing consumer")))))))
+  (stop [{:keys [running?] :as this}]
+    (reset! running? false)
+    this))
+
+(comment
+  (defn callback
+    ;; FIXME: update to expect single map arg...
+    [comp k v meta]
+    (log/info "demo callback" {:comp comp :k k :v v :meta meta}))
+
+  (def sub (map->KafkaSubscriber
+            {:bootstrap-servers "kafka:9092"
+             :group-id "test-subscriber"
+             :topics ["foo" "bar"]
+             :poll-timeout-ms 1000
+             :schema-registry-url "http://schema_registry:8081"
+             :record-callback callback}))
+  (def sub (component/start sub))
+  (def sub (component/stop sub))
+  )

--- a/src/rp/kafka/kafka_subscriber.clj
+++ b/src/rp/kafka/kafka_subscriber.clj
@@ -50,12 +50,10 @@
                     :partition (.partition rec)
                     :offset (.offset rec)
                     :timestamp (.timestamp rec)}]
-          ;; FIXME: switch to this style after initial alert-service migration
-          #_(record-callback {:component component
+          (record-callback {:component component
                             :k k
                             :v v
-                            :meta meta})
-          (record-callback component k v meta))
+                            :meta meta}))
         (catch Throwable t
           (common/report-throwable component t "Caught exception handling record" {:rec rec}))))
     (when (seq recs)
@@ -92,9 +90,8 @@
 
 (comment
   (defn callback
-    ;; FIXME: update to expect single map arg...
-    [comp k v meta]
-    (log/info "demo callback" {:comp comp :k k :v v :meta meta}))
+    [{:keys [k v meta component] :as args}]
+    (log/info "demo callback" args))
 
   (def sub (map->KafkaSubscriber
             {:bootstrap-servers "kafka:9092"

--- a/src/rp/kafka/publisher.clj
+++ b/src/rp/kafka/publisher.clj
@@ -1,0 +1,29 @@
+(ns rp.kafka.publisher)
+
+(defprotocol Publisher
+  (publish [this k v] [this k v opts]))
+
+;; A mock implementation for tests that keeps a record of all publish calls in an atom.
+(defrecord MockPublisher [store]
+  Publisher
+  (publish [this k v]
+    (swap! store
+           conj
+           {:k k
+            :v v}))
+  (publish [this k v opts]
+    (swap! store
+           conj
+           {:k k
+            :v v
+            :opts opts})))
+
+;; Convenience factory fn
+(defn mock-publisher
+  []
+  (->MockPublisher (atom [])))
+
+;; Mock helper
+(defn get-mock-store
+  [publisher]
+  @(:store publisher))

--- a/src/rp/kafka/schema.clj
+++ b/src/rp/kafka/schema.clj
@@ -1,0 +1,11 @@
+(ns rp.kafka.schema
+  (:require [cheshire.core :as json]
+            [rp.kafka.avro :as avro]))
+
+(defn fetch-schema
+  [registry-url subject version]
+  (-> (format "%s/subjects/%s/versions/%s" registry-url subject version)
+      slurp
+      (json/parse-string true)
+      :schema
+      avro/parse-schema))

--- a/test/rp/kafka/avro_test.clj
+++ b/test/rp/kafka/avro_test.clj
@@ -1,0 +1,27 @@
+(ns rp.kafka.avro-test
+  (:require [clojure.test :refer :all]
+            [rp.kafka.avro :as sut]
+            [cheshire.core :as json]))
+
+(def schema-clj {:namespace "com.test"
+                 :type "record"
+                 :name "Test"
+                 :fields [{:name "a_string" :type "string"}
+                          {:name "an_int" :type "int"}]})
+
+(def schema (sut/parse-schema (json/encode schema-clj)))
+
+(deftest round-trip-test
+  (let [payload {:a_string "Hello"
+                 :an_int 23}]
+    (testing "snake_case passes through"
+      (is (= payload
+             (->> payload
+                  (sut/->java schema)
+                  sut/->clj ))))
+    (testing "translates kebab-case to snake_case"
+      (is (= payload
+             (->> {:a-string "Hello"
+                   :an-int 23}
+                  (sut/->java schema)
+                  sut/->clj ))))))


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-474)

Opening for early visibility.
It's pretty much a straight extraction from alert-service, except that I removed the metrics tracking and Sentry exception reporting; I thought both were too opinionated for a generic library.

I've got alert-service working with it locally, but still need to:
- update alert-service to pass a callback for exception handling
- update alert-service to track relevant metrics instead of depending on the components to track generic metrics
- setup the library build/release process