### PR TITLE
Simplify release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -65,7 +65,7 @@ fi
 
 lein vcs commit
 
-export RELEASED_VERSION=v$(java -cp ~/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar clojure.main -e '(do (let [p (read-string (slurp "project.clj"))] (nth p 2)))' | tr -d '"')
+export RELEASED_VERSION=v$(head -1 project.clj | awk '{print $3}' | tr -d '"')
 git tag -m "Release $RELEASED_VERSION" $RELEASED_VERSION
 
 lein do deploy releases, change version leiningen.release/bump-version


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-569)

I noticed that the release failed to build the git tag
on the jenkins slaves it happened to run on.
(Instead of `v0.0.3` the tag was just `v`.)
After investigating I see that the release script (which I copied
from one of our other libs) is doing some creative scripting
that runs clojure via a specific jar file which it turns out is missing
on some of the slaves (why the slaves differ is another matter).

Anyway there's no need to call out to clojure just to pluck out the
version from the project file like this; the same thing could be
accomplished with some good old unix commands.